### PR TITLE
allow for repeated request that provide days to reservation rather than an explicit date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,6 @@ build: clean poetry-config
 	poetry install -vvv
 
 test:
+	poetry run black --check resy_bot main.py
 	poetry run pytest tests/ --cov=resy_bot
-	poetry run mypy resy_bot
+	poetry run mypy resy_bot main.py

--- a/README.md
+++ b/README.md
@@ -89,6 +89,37 @@ to start searching for slots
 to start searching for slots
 
 
+#### Timed Repeated Reservation Request
+
+Some reservations are particularly hard to get. For that case, we can create a 
+`TimedRepeatedReservationRequest` JSON - this will allow us to simply specify the
+number of days in advance that a reservation goes live and run repeatedly across
+several days. 
+
+The nice piece of this approach is it allows us to keep the JSON constant rather
+than repeatedly changing the `ideal_date` field.
+
+This object will look nearly identical to the `TimedReservationRequest`, just with the
+`ideal_date` field swapped out for `days_from_now`
+
+```json
+{
+"reservation_request": {
+  "party_size": 4,
+  "venue_id": 12345,
+  "window_hours": 1,
+  "prefer_early": false,
+  "days_from_now": 14,
+  "ideal_hour": 19,
+  "ideal_minute": 30,
+  "preferred_type": "Dining Room"
+},
+  "expected_drop_hour": "10",
+  "expected_drop_minute": "0"
+}
+```
+
+
 ### Command Line Execution
 
 This application can be run from the command line. To do so, 
@@ -99,3 +130,9 @@ the command should be formatted as
 From here, the application will wait until the time specified by 
 `expected_drop_hour` and `expected_drop_minute` to begin searching
 for available timeslots.
+
+If you are looking to make a repeated reservation (see above for some discussion of the 
+configuration for this case), you must also include the `--repeated_request` argument.
+As such, the command should look like:
+
+`poetry run python main.py <path/to/credentials.json> <path/to/reservation/request.json> --repeated_request`

--- a/resy_bot/api_access.py
+++ b/resy_bot/api_access.py
@@ -47,7 +47,11 @@ class ResyApiAccess:
     def auth(self, body: AuthRequestBody) -> AuthResponseBody:
         auth_url = RESY_BASE_URL + ResyEndpoints.PASSWORD_AUTH.value
 
-        resp = self.session.post(auth_url, data=body.dict(), headers={"content-type": "application/x-www-form-urlencoded"})
+        resp = self.session.post(
+            auth_url,
+            data=body.dict(),
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
 
         if not resp.ok:
             raise HTTPError(f"Failed to get auth: {resp.status_code}, {resp.text}")

--- a/resy_bot/manager.py
+++ b/resy_bot/manager.py
@@ -121,7 +121,10 @@ class ResyManager:
         drop_time = self._get_drop_time(reservation_request)
 
         while True:
-            if datetime.now() < (drop_time - timedelta(milliseconds=self.retry_config.seconds_between_retries)):
+            early_start_td = timedelta(
+                milliseconds=self.retry_config.seconds_between_retries
+            )
+            if datetime.now() < (drop_time - early_start_td):
                 continue
 
             logger.info(f"time reached, making a reservation now! {datetime.now()}")

--- a/resy_bot/model_builders.py
+++ b/resy_bot/model_builders.py
@@ -1,6 +1,8 @@
-from datetime import date
+from datetime import date, timedelta
 from resy_bot.models import (
     ReservationRequest,
+    TimedReservationRequest,
+    TimedRepeatedReservationRequest,
     AuthRequestBody,
     FindRequestBody,
     DetailsRequestBody,
@@ -10,6 +12,21 @@ from resy_bot.models import (
     ResyConfig,
     PaymentMethod,
 )
+
+
+def build_timed_reservation_request(
+    repeat_request: TimedRepeatedReservationRequest,
+) -> TimedReservationRequest:
+    repeat_request_dict = repeat_request.reservation_request.dict()
+    days_from_now = repeat_request_dict.pop("days_from_now")
+    ideal_date = date.today() + timedelta(days=days_from_now)
+    request = ReservationRequest(ideal_date=ideal_date, **repeat_request_dict)
+
+    return TimedReservationRequest(
+        reservation_request=request,
+        expected_drop_hour=repeat_request.expected_drop_hour,
+        expected_drop_minute=repeat_request.expected_drop_minute,
+    )
 
 
 def build_find_request_body(reservation: ReservationRequest) -> FindRequestBody:

--- a/resy_bot/models.py
+++ b/resy_bot/models.py
@@ -26,6 +26,21 @@ class ReservationRequest(BaseModel):
     preferred_type: Optional[str]
 
 
+class RepeatedReservationRequest(BaseModel):
+    """
+    instead of specifying a date, specify the number of days from now
+    """
+
+    venue_id: str
+    party_size: int
+    days_from_now: int
+    ideal_hour: int
+    ideal_minute: int
+    window_hours: int
+    prefer_early: bool
+    preferred_type: Optional[str]
+
+
 class ReservationRetriesConfig(BaseModel):
     seconds_between_retries: float
     retry_duration: float
@@ -33,6 +48,12 @@ class ReservationRetriesConfig(BaseModel):
 
 class TimedReservationRequest(BaseModel):
     reservation_request: ReservationRequest
+    expected_drop_hour: int
+    expected_drop_minute: int
+
+
+class TimedRepeatedReservationRequest(BaseModel):
+    reservation_request: RepeatedReservationRequest
     expected_drop_hour: int
     expected_drop_minute: int
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,8 +5,10 @@ from random import randint
 from resy_bot.models import (
     ResyConfig,
     ReservationRequest,
+    RepeatedReservationRequest,
     ReservationRetriesConfig,
     TimedReservationRequest,
+    TimedRepeatedReservationRequest,
     Slot,
     SlotConfig,
     SlotDate,
@@ -39,6 +41,20 @@ class ReservationRequestFactory(factory.Factory):
     preferred_type = factory.Faker("bs")
 
 
+class RepeatedReservationRequestFactory(factory.Factory):
+    class Meta:
+        model = RepeatedReservationRequest
+
+    venue_id = factory.Faker("bs")
+    party_size = factory.Faker("random_int")
+    days_from_now = factory.Faker("random_int")
+    ideal_hour = factory.LazyFunction(lambda: randint(1, 23))
+    ideal_minute = factory.LazyFunction(lambda: randint(0, 59))
+    window_hours = factory.LazyFunction(lambda: randint(0, 4))
+    prefer_early = factory.Faker("boolean")
+    preferred_type = factory.Faker("bs")
+
+
 class ReservationRetriesConfigFactory(factory.Factory):
     class Meta:
         model = ReservationRetriesConfig
@@ -52,6 +68,15 @@ class TimedReservationRequestFactory(factory.Factory):
         model = TimedReservationRequest
 
     reservation_request = factory.SubFactory(ReservationRequestFactory)
+    expected_drop_hour = factory.LazyFunction(lambda: randint(1, 24))
+    expected_drop_minute = factory.LazyFunction(lambda: randint(0, 60))
+
+
+class TimedRepeatedReservationRequestFactory(factory.Factory):
+    class Meta:
+        model = TimedRepeatedReservationRequest
+
+    reservation_request = factory.SubFactory(RepeatedReservationRequestFactory)
     expected_drop_hour = factory.LazyFunction(lambda: randint(1, 24))
     expected_drop_minute = factory.LazyFunction(lambda: randint(0, 60))
 

--- a/tests/test_model_builders.py
+++ b/tests/test_model_builders.py
@@ -1,23 +1,36 @@
 from datetime import date
+from unittest.mock import patch
 
 from tests.factories import (
     ReservationRequestFactory,
     SlotFactory,
     ResyConfigFactory,
     DetailsResponseBodyFactory,
+    TimedRepeatedReservationRequestFactory,
 )
 from resy_bot.models import (
     FindRequestBody,
     DetailsRequestBody,
-    AuthRequestBody,
-    BookRequestBody,
 )
 from resy_bot.model_builders import (
+    build_timed_reservation_request,
     build_find_request_body,
     build_get_slot_details_body,
     build_auth_request_body,
     build_book_request_body,
 )
+
+
+@patch("resy_bot.model_builders.date")
+def test_build_timed_reservation_request(mock_date):
+    mock_date.today.return_value = date(year=2000, month=4, day=28)
+    repeated_request = TimedRepeatedReservationRequestFactory.create(
+        reservation_request__days_from_now=5
+    )
+    request = build_timed_reservation_request(repeated_request)
+
+    assert request.reservation_request.ideal_date == date(year=2000, month=5, day=3)
+    assert request.expected_drop_hour == repeated_request.expected_drop_hour
 
 
 def test_build_find_request_body():


### PR DESCRIPTION
it's a pain to constantly change dates and recalculate when the reservation drops. add a `repeated_request` flag to allow for requests that simply specify the number of days from today until the reservation drops